### PR TITLE
Define engine restriction

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     },
     "dependencies": {
     },
+    "engines": { "node": "<6.0.0" },
+    "engineStrict": true,
     "devDependencies": {
         "nodeunit": "^0.9.1"
     },


### PR DESCRIPTION
The default string encoding used by the crypto module [changed in v6.0.0 from binary to utf8](https://github.com/nodejs/node/commit/b010c8716498dca398e61c388859fea92296feb3).