### PR TITLE
Update rdcrypto.js

### DIFF
--- a/lib/rdcrypto.js
+++ b/lib/rdcrypto.js
@@ -20,7 +20,7 @@ RDCrypto.prototype.encrypt = function (value)
 {
     var cipher = crypto.createCipheriv(this.cryptoMethod, this.secret, this.iv);
     var encrypted = cipher.update(value, 'utf8', 'binary') + cipher.final('binary');
-    var hexVal = new Buffer(encrypted, 'binary');
+    var hexVal = Buffer.from(encrypted, 'binary');
     var newEncrypted = hexVal.toString('hex');
 
     return this.cryptoMarker + newEncrypted;


### PR DESCRIPTION
Removed deprecation warning:
[DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.